### PR TITLE
Hide the status message when the selected file changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,12 @@ document.addEventListener("DOMContentLoaded", () => {
     const uploadFileInput = document.getElementById("uploadFileInput");
     const uploadFileButton = document.getElementById("uploadFileButton");
 
+    // When selected file changes, hide the status message
+    uploadFileInput.addEventListener("change", async () => {
+        const ref = document.getElementById('result-message-container');
+        ref.removeAttribute('class');
+    });
+
     // When upload button clicked, get upload details and then perform file
     // upload with AJAX.
     uploadFileButton.addEventListener("click", async () => {


### PR DESCRIPTION
Currently, if you upload one file, then upload another, it's unclear that the second file was successfully uploaded, since the status message from the first file remains visible. This change hides the status message when the file input element fires a `change` event. 